### PR TITLE
changed autoresizingMask to FlexibleWidth for top overscroll color in UITableView

### DIFF
--- a/Extensions/UITableViewExtensions.swift
+++ b/Extensions/UITableViewExtensions.swift
@@ -13,19 +13,20 @@ extension UITableView {
     public func standardTheme(topOverscrollColor topColor: UIColor? = nil, bottomOverscrollColor bottomColor: UIColor? = nil) {
 
         // Top overflow
-        // http://stackoverflow.com/a/20236562
-        if (topColor != nil) {
+        // http://stackoverflow.com/a/20236562 - based on this
+        if let topColor = topColor {
             var frame = self.bounds ?? CGRectZero
             frame.origin.y = -(frame.size.height ?? 0.0)
             
             let backgroundView = UIView(frame: frame)
-            backgroundView.backgroundColor = topColor!
+            backgroundView.autoresizingMask = UIViewAutoresizing.FlexibleWidth
+            backgroundView.backgroundColor = topColor
             self.insertSubview(backgroundView, atIndex: 0)
         }
         
         // Bottom overflow
-        if (bottomColor != nil) {
-            self.backgroundColor = bottomColor!
+        if let bottomColor = bottomColor {
+            self.backgroundColor = bottomColor
         }
 
         // Remove filler cells


### PR DESCRIPTION
fixed issue with overscroll color not taking up the full width.
